### PR TITLE
Enable short-circuiting eval for And/Or

### DIFF
--- a/src/main/scala/rules/Evaluator.scala
+++ b/src/main/scala/rules/Evaluator.scala
@@ -1199,38 +1199,18 @@ object evaluator extends EvaluationRules with Immutable {
         evalBinOpPc(s, e0, e1, (t1, t2) => And(t1, t2), pve, v, generateChecks)(Q)
 
       /* Short-circuiting evaluation of AND */
-      /* Only do short-circuiting in consume under the assumption that Diff and Translate
-         do NOT change the order of asserted conjuncts. Currently, Diff's conversion into CNF form changes
-         the order. This may be unavoidable due to CNF form. So, currently short-circuiting in consume is turned off. - JWD */
-      /* Turning off short-circuiting may mean we cannot support specs in a way that users would like in 
-         postconditions, asserts, loop invariants, and predicate bodies.
-         For consistency I've turned short-circuiting off for all specs, aka in produce as well - JWD */
       case ae @ ast.And(e0, e1) =>
-        //if (s.generateChecks)
-          evalBinOpPc(s, e0, e1, (t1, t2) => And(t1, t2), pve, v, generateChecks)(Q)
-        //else {
-          //val flattened = flattenOperator(ae, {case ast.And(e2, e3) => Seq(e2, e3)})
-          //evalSeqShortCircuit(And, s, flattened, pve, v)(Q)
-        //}
+        val flattened = flattenOperator(ae, {case ast.And(e2, e3) => Seq(e2, e3)})
+        evalSeqShortCircuit(And, s, flattened, pve, v)(Q)
 
       /* Strict evaluation of OR */
       case ast.Or(e0, e1) if Verifier.config.disableShortCircuitingEvaluations() =>
         evalBinOpPc(s, e0, e1, (t1, t2) => Or(t1, t2), pve, v, generateChecks)(Q)
 
       /* Short-circuiting evaluation of OR */
-      /* Only do short-circuiting in consume under the assumption that Diff and Translate
-         do NOT change the order of asserted conjuncts. Currently, Diff's conversion into CNF form changes
-         the order. This may be unavoidable due to CNF form. So, currently short-circuiting in consume is turned off. - JWD */
-      /* Turning off short-circuiting means we cannot support specs like: right == 0 || (left % right >= 0) in 
-         postconditions, asserts, loop invariants, and predicate bodies where they may be consumed.
-         For consistency I've turned short-circuiting off for all specs, aka in produce as well - JWD */
       case oe @ ast.Or(e0, e1) =>
-        //if (s.generateChecks)
-          evalBinOpPc(s, e0, e1, (t1, t2) => Or(t1, t2), pve, v, generateChecks)(Q)
-        //else {
-        //  val flattened = flattenOperator(oe, {case ast.Or(e2, e3) => Seq(e2, e3)})
-        //  evalSeqShortCircuit(Or, s, flattened, pve, v)(Q)
-        //}
+        val flattened = flattenOperator(oe, {case ast.Or(e2, e3) => Seq(e2, e3)})
+        evalSeqShortCircuit(Or, s, flattened, pve, v)(Q)
 
       /*
       case implies @ ast.Implies(e0, e1) =>
@@ -2345,10 +2325,7 @@ object evaluator extends EvaluationRules with Immutable {
 
     type brFun = (State, Verifier) => VerificationResult
 
-    // TODO: Find out and document why swapIfAnd is needed
-    val (stop, swapIfAnd) =
-      if(constructor == Or) (True(), (a: brFun, b: brFun) => (a, b))
-      else (False(), (a: brFun, b: brFun) => (b, a))
+    val stop = if (constructor == Or) True() else False()
 
     eval(s, exps.head, pve, v)((s1, t0, v1) => {
       t0 match {
@@ -2366,7 +2343,7 @@ object evaluator extends EvaluationRules with Immutable {
             }
 
           joiner.join[Term, Term](s1, v1)((s2, v2, QB) =>            
-            brancher.branch(s2, t0, exps.head, branchCondOrigin, v2, true) _ tupled swapIfAnd(
+            brancher.branch(s2, if (constructor == Or) t0 else Not(t0), exps.head, branchCondOrigin, v2, true)(
               (s3, v3) => QB(s3, constructor(Seq(t0)), v3),
               (s3, v3) => evalSeqShortCircuit(constructor, s3, exps.tail, pve, v3)(QB))
             ){case Seq(ent) =>


### PR DESCRIPTION
short circuiting was turned off, under the assumption that Diff and Translate change the order of asserted conjuncts (refer issue #53 -> it corrects how while loop condition is framed in execute, but also disables short-circuiting eval). However, the actual issue was with Viper's implementation of short-circuiting eval rule which used to swap conjuncts in the case of && (before it was corrected in Silicon). Corrected implementation removed swapIfAnd (source of issue).

Now, short-circuiting eval should be used in all cases for And/Or. 