### PR TITLE
Duplicate Predicates and Fixes

### DIFF
--- a/src/main/scala/rules/ChunkSupporter.scala
+++ b/src/main/scala/rules/ChunkSupporter.scala
@@ -127,7 +127,6 @@ object chunkSupporter extends ChunkSupportRules with Immutable {
       case (Complete(), s2, h2, optCh2) =>
         Q(s2.copy(h = s.h), h2, optCh2.map(_.snap), v)
 
-      // should never reach this case
       case _ if v.decider.checkSmoke() =>
         Success()
 

--- a/src/main/scala/rules/Producer.scala
+++ b/src/main/scala/rules/Producer.scala
@@ -332,29 +332,25 @@ object producer extends ProductionRules with Immutable {
         evalspc(s0, eArgs, _ => pve, v, false)((s1, tArgs, v1) =>
           evalpc(s1, perm, pve, v1, false)((s2, tPerm, v2) => {
             val s2_0 = s2.copy(generateChecks = true)
-            if (chunkSupporter.inHeap(s2_0.h, s2_0.h.values, predicate, tArgs, v2)) {
-              // Actually because it's in the heap, but don't know how to do that yet
-              createFailure(pve dueTo NegativePermission(perm), v2, s2_0) }
-            else {
-              val snap = sf(
-                predicate.body.map(v2.snapshotSupporter.optimalSnapshotSort(_, Verifier.program)._1)
-                            .getOrElse(sorts.Snap), v2)
-              val gain = PermTimes(tPerm, s2_0.permissionScalingFactor)
+            val snap = sf(
+              predicate.body.map(v2.snapshotSupporter.optimalSnapshotSort(_, Verifier.program)._1)
+                          .getOrElse(sorts.Snap), v2)
+            val gain = PermTimes(tPerm, s2_0.permissionScalingFactor)
 /*            if (s2.qpPredicates.contains(predicate)) {
-              val formalArgs = s2.predicateFormalVarMap(predicate)
-              val trigger = (sm: Term) => PredicateTrigger(predicate.name, sm, tArgs)
-              quantifiedChunkSupporter.produceSingleLocation(
-                s2, predicate, formalArgs, tArgs, snap, gain, trigger, v2)(Q)
-            } else {
+            val formalArgs = s2.predicateFormalVarMap(predicate)
+            val trigger = (sm: Term) => PredicateTrigger(predicate.name, sm, tArgs)
+            quantifiedChunkSupporter.produceSingleLocation(
+              s2, predicate, formalArgs, tArgs, snap, gain, trigger, v2)(Q)
+          } else {
 */
-              val snap1 = snap.convert(sorts.Snap)
-              val ch = BasicChunk(PredicateID, BasicChunkIdentifier(predicate.name), tArgs, snap1, gain)
-              chunkSupporter.produce(s2_0, s2_0.h, ch, v2)((s3, h3, v3) => {
-                /* if (Verifier.config.enablePredicateTriggersOnInhale() && s3.functionRecorder == NoopFunctionRecorder) {
-                  v3.decider.assume(App(Verifier.predicateData(predicate).triggerFunction, snap1 +: tArgs))
-                } */
-                Q(s3.copy(h = h3), v3)})
-            }}))
+            val snap1 = snap.convert(sorts.Snap)
+            val ch = BasicChunk(PredicateID, BasicChunkIdentifier(predicate.name), tArgs, snap1, gain)
+            chunkSupporter.produce(s2_0, s2_0.h, ch, v2)((s3, h3, v3) => {
+              /* if (Verifier.config.enablePredicateTriggersOnInhale() && s3.functionRecorder == NoopFunctionRecorder) {
+                v3.decider.assume(App(Verifier.predicateData(predicate).triggerFunction, snap1 +: tArgs))
+              } */
+              Q(s3.copy(h = h3), v3)})
+          }))
 
 /*
       case wand: ast.MagicWand if s.qpMagicWands.contains(MagicWandIdentifier(wand, Verifier.program)) =>

--- a/src/main/scala/rules/Producer.scala
+++ b/src/main/scala/rules/Producer.scala
@@ -303,14 +303,14 @@ object producer extends ProductionRules with Immutable {
  *      letSupporter.handle[ast.Exp](s, let, pve, v)((s1, g1, body, v1) =>
  *        produceR(s1.copy(g = s1.g + g1), sf, body, pve, v1)(Q))
  */
-      case ast.FieldAccessPredicate(ast.FieldAccess(eRcvr, field), perm) =>
+      case loc @ ast.FieldAccessPredicate(locacc @ ast.FieldAccess(eRcvr, field), perm) =>
         val s0 = s.copy(generateChecks = false)
         evalpc(s0, eRcvr, pve, v, false)((s1, tRcvr, v1) =>
           evalpc(s1, perm, pve, v1, false)((s2, tPerm, v2) => {
             val s2_0 = s2.copy(generateChecks = true)
-            if(chunkSupporter.inHeap(s2_0.h, s2_0.h.values, field, Seq(tRcvr), v2)) {
-              // NEED: Actually because it's in the heap, but don't know how to do that yet
-              createFailure(pve dueTo NegativePermission(perm), v2, s2_0) }
+            if(chunkSupporter.inHeap(s2_0.h, s2_0.h.values, field, Seq(tRcvr), v2) && !v2.decider.checkSmoke()) {
+              createFailure(pve dueTo LocInHeap(locacc), v2, s2_0) 
+            }
             else {
               val snap = sf(v2.symbolConverter.toSort(field.typ), v2)
               val gain = PermTimes(tPerm, s2_0.permissionScalingFactor)


### PR DESCRIPTION
Does 3 things:
1. Relaxes duplicate predicate restriction
2. Better error message for duplicate fields - `LocInHeap` defined in `silver-gv`. 
3. Duplicate fields are now allowed if  symbolic state `=> false`
